### PR TITLE
Initial commit of coverage tool for PPC64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist-newstyle
 .cabal-sandbox
 .stack-work/
 TAGS
+/dismantle-tablegen/regex/

--- a/dismantle-coverage/LICENSE
+++ b/dismantle-coverage/LICENSE
@@ -1,0 +1,30 @@
+Copyright (c) 2018, Galois Inc.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Galois Inc. nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/dismantle-coverage/Main.hs
+++ b/dismantle-coverage/Main.hs
@@ -1,0 +1,95 @@
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module Main where
+
+import           Control.Monad
+import           Data.List
+import           Data.Monoid
+import qualified Data.Set            as S
+import qualified Data.Text.Lazy.IO   as TL
+import qualified Dismantle.PPC.ISA   as PPC
+import qualified Dismantle.Tablegen  as D
+import           Numeric
+import qualified Options.Applicative as O
+import           System.Directory
+
+options :: O.Parser Options
+options =
+  Options
+    <$> O.strArgument ( O.metavar "FILE" <> O.help "The tablegen output to parse")
+    <*> O.strArgument ( O.metavar "PPC" <> O.help "The directory of semantics files for PPC64")
+    <*> O.switch
+          ( O.long "Dump undefined PPC64 semantics"
+          <> O.short 'd'
+          <> O.help "Whether to dump undefined semantics"
+          )
+
+-- | Options for command-line tool
+data Options
+  = Options
+  { tableGenFile :: String
+  , semanticsDirectory :: String
+  , dumpUndefinedBaseInsts :: Bool
+  } deriving (Show, Eq)
+
+main :: IO ()
+main = O.execParser opts >>= go
+  where
+    opts = O.info (O.helper <*> options) O.fullDesc
+
+go :: Options -> IO ()
+go opts = do
+  t <- TL.readFile $ tableGenFile opts
+  case D.parseTablegen (tableGenFile opts) t of
+    Left e -> fail e
+    Right records -> do
+      let descriptors = D.parsableInstructions PPC.isa (D.filterISA PPC.isa records)
+          ev   = [ d | d <- descriptors, "HasSPE" `elem` D.idPredicates d ]
+          alti = [ d | d <- descriptors, "HasAltivec" `elem` D.idPredicates d ]
+          vsx  = [ d | d <- descriptors, "HasVSX" `elem` D.idPredicates d ]
+          base = [ d | d <- descriptors, null (D.idPredicates d) ]
+      files <- fmap stripSuffix <$> do
+        (++) <$> listDirectory (semanticsDirectory opts)
+             <*> do listDirectory $ toManual (semanticsDirectory opts)
+      let definedEV   = getDefined ev files
+          definedAlti = getDefined alti files
+          definedVSX  = getDefined vsx files
+          definedBase = getDefined base files
+      showCoverage "Alti" definedAlti alti
+      showCoverage "VSX" definedVSX vsx
+      showCoverage "Base" definedBase base
+      when (dumpUndefinedBaseInsts opts) $ do
+        writeFile "unsupported.txt"
+          $ intercalate "\n"
+          $ S.toList
+          $ getUndefined base files
+  where
+    stripSuffix :: String -> String
+    stripSuffix = takeWhile (/='.')
+
+    toManual :: String -> String
+    toManual = (++"manual/") . reverse . dropWhile (/='/') . reverse
+
+    retrieve :: Ord a
+             => (S.Set String -> S.Set a -> b)
+             -> [D.InstructionDescriptor]
+             -> [a]
+             -> b
+    retrieve f descriptor files =
+      S.fromList (D.idMnemonic <$> descriptor)
+        `f` S.fromList files
+
+    getDefined = retrieve S.intersection
+    getUndefined = retrieve S.difference
+
+    showFloat x = showFFloat (Just 2) x ""
+
+    showCoverage :: [Char] -> S.Set String -> [D.InstructionDescriptor] -> IO ()
+    showCoverage name defined total = do
+      putStrLn $ intercalate "\n" [
+          "Extension: " ++ name
+        , "Defined: " ++ do showFloat $ fromIntegral (S.size defined)
+        , "Total: " ++ do showFloat $ fromIntegral (length total)
+        , showFloat ((fromIntegral (S.size defined) / fromIntegral (length total)) * 100) ++ "%"
+        ]
+      putStrLn ""

--- a/dismantle-coverage/Setup.hs
+++ b/dismantle-coverage/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/dismantle-coverage/default.nix
+++ b/dismantle-coverage/default.nix
@@ -1,0 +1,23 @@
+{ pkgs ? <nixpkgs>, compiler ? "ghc822" }:
+let
+   config = {
+     packageOverrides = pkgs: with pkgs.haskell.lib; {
+       haskell = pkgs.haskell // {
+         packages = pkgs.haskell.packages // {
+	   ${compiler} = pkgs.haskell.packages.${compiler}.override {
+              overrides = self: super: {
+                regex = self.callPackage ./regex {};
+              };
+            };
+	  };
+        };
+      };
+    };
+  p = import pkgs { inherit config; };
+  dismantle-tablegen = p.haskell.packages.${compiler}.callPackage ../dismantle-tablegen/dismantle-tablegen.nix {};
+  dismantle-ppc = p.haskell.lib.dontCheck (p.haskell.packages.${compiler}.callPackage ../dismantle-ppc/dismantle-ppc.nix { inherit dismantle-tablegen; });
+in
+  p.haskell.packages.${compiler}.callPackage ./dismantle-coverage.nix {
+    inherit dismantle-tablegen dismantle-ppc;
+  }
+

--- a/dismantle-coverage/dismantle-coverage.cabal
+++ b/dismantle-coverage/dismantle-coverage.cabal
@@ -1,0 +1,21 @@
+name:                dismantle-coverage
+version:             0.1.0.0
+synopsis:            Coverage tool for various ISAs
+license:             BSD3
+license-file:        LICENSE
+author:              Galois Inc.
+maintainer:          david@galois.com
+build-type:          Simple
+extra-source-files:  ChangeLog.md
+cabal-version:       >=1.10
+
+executable dismantle-coverage
+  main-is:             Main.hs
+  build-depends:       base
+                     , containers
+                     , text
+                     , dismantle-ppc
+                     , dismantle-tablegen
+                     , optparse-applicative
+                     , directory
+  default-language:    Haskell2010

--- a/dismantle-coverage/dismantle-coverage.nix
+++ b/dismantle-coverage/dismantle-coverage.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, base, containers, directory, dismantle-ppc
+, dismantle-tablegen, optparse-applicative, stdenv, text
+}:
+mkDerivation {
+  pname = "dismantle-coverage";
+  version = "0.1.0.0";
+  src = ./.;
+  isLibrary = false;
+  isExecutable = true;
+  executableHaskellDepends = [
+    base containers directory dismantle-ppc dismantle-tablegen
+    optparse-applicative text
+  ];
+  description = "Coverage tool for various ISAs";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/dismantle-tablegen/src/Dismantle/Tablegen/Types.hs
+++ b/dismantle-tablegen/src/Dismantle/Tablegen/Types.hs
@@ -72,6 +72,7 @@ data InstructionDescriptor =
                         , idDecoderNamespace :: String
                         , idAsmString :: String
                         , idPseudo :: Bool
+                        , idPredicates :: [String]
                         , idDefaultPrettyVariableValues :: [(String, String)]
                         , idPrettyVariableOverrides :: [(String, String)]
                         }

--- a/dismantle-tablegen/tests/Parser.hs
+++ b/dismantle-tablegen/tests/Parser.hs
@@ -3,6 +3,7 @@ module Parser ( parserTests ) where
 
 import Control.DeepSeq ( deepseq )
 import Control.Monad (when, forM)
+import Data.List (delete)
 import Data.Monoid ((<>))
 import qualified Data.Text.IO as TS
 import qualified Data.Text.Lazy as TL
@@ -28,7 +29,8 @@ mkParserTestGroup (pkg, files) = do
 
 requireGlob :: String -> String -> IO [FilePath]
 requireGlob ty pat = do
-    paths <- mapM canonicalizePath =<< G.namesMatching pat
+    names <- G.namesMatching pat
+    paths <- mapM canonicalizePath (delete "../dismantle-coverage" names)
     when (null paths) $ do
         die $ "Error: could not find any " <> ty <> " matching " <> show pat
     return paths


### PR DESCRIPTION
Displays coverage of PPC64 instructions (and its various extensions) against defined semantics, `Base`, `EV`, `AltiVec` and `VSX`.
