### PR TITLE
Support building with GHC 9.4

### DIFF
--- a/.github/workflows/ci-matrix.yml
+++ b/.github/workflows/ci-matrix.yml
@@ -18,23 +18,19 @@ jobs:
     strategy:
       matrix:
         arch: ['tablegen', 'arm', 'thumb', 'ppc', 'aarch64', 'arm-xml']
-        ghc: ['8.8.4', '8.10.7', '9.0.2', '9.2.2']
-        cabal: ['3.6.2.0']
+        ghc: ['8.10.7', '9.2.7', '9.4.4']
+        cabal: ['3.8.1.0']
         os: [ubuntu-latest, macOS-latest, windows-latest]
         exclude:
           # Only test macOS and Windows on the latest supported GHC versions
           - os: macOS-latest
-            ghc: 8.8.4
-          - os: macOS-latest
             ghc: 8.10.7
           - os: macOS-latest
-            ghc: 9.0.2
-          - os: windows-latest
-            ghc: 8.8.4
+            ghc: 9.2.7
           - os: windows-latest
             ghc: 8.10.7
           - os: windows-latest
-            ghc: 9.0.2
+            ghc: 9.2.7
           # This configuration runs out of memory
           - os: windows-latest
             arch: aarch64

--- a/dismantle-arm-xml/src/Data/BitMask.hs
+++ b/dismantle-arm-xml/src/Data/BitMask.hs
@@ -32,6 +32,7 @@ a lookup will retrieve all elements with a key that matches the provided mask.
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Data.BitMask
   (

--- a/dismantle-tablegen/dismantle-tablegen.cabal
+++ b/dismantle-tablegen/dismantle-tablegen.cabal
@@ -66,7 +66,7 @@ library
                        hashable,
                        unordered-containers,
                        zlib >= 0.6 && < 0.7,
-                       text >= 1 && < 2,
+                       text >= 1 && < 2.1,
                        vector,
                        tasty >= 0.10,
                        tasty-hunit,


### PR DESCRIPTION
This contains a handful of small tweaks needed to make the libraries in the `dismantle` repo build with GHC 9.4:

* I have bumped the upper version bounds on `text` to allow building with `text-2.0.*`, which is bundled with GHC 9.4.
* GHC 9.4 is pickier about undecidable instance checking. See [this section](https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.4?version_id=24540b698481cf2b0bd11029b58eaddc0fbfbb31#stricter-undecidableinstances-checking) of the GHC 9.4 Migration Guide. As a result, I had to explicitly enable `UndecidableInstances` in `Data.BitMask` to make it compile.
* I have bumped the `parameterized-utils` submodule to bring in the changes from https://github.com/GaloisInc/parameterized-utils/pull/146, which is needed to make it build with GHC 9.4.